### PR TITLE
Compile ESMRE using Cython < 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython"]
+requires = ["setuptools", "wheel", "Cython<3"]


### PR DESCRIPTION
The recent release of Cython (version 3) broke the compilation of ESMRE c module:

```
[1/1] Cythonizing src/esm.pyx
 File: /home/d/deleteme/esmre/src/esm.pyx
  tree = Parsing.p_module(s, pxd, full_module_name)

Error compiling Cython file:
------------------------------------------------------------
...
        self._index = aho_corasick.ac_index_new()
        if self._index is NULL:
            raise MemoryError()

    def __dealloc__(self):
        aho_corasick.ac_index_free(self._index, decref_result_object)
                                                ^
------------------------------------------------------------

src/esm.pyx:28:48: Cannot assign type 'ac_error_code (void *, void *) except *' to 'ac_free_function'

Error compiling Cython file:
------------------------------------------------------------
...
        result_list = []

        status = aho_corasick.ac_index_query_cb(self._index,
                                          phrase,
                                          len(phrase),
                                          append_result,
                                          ^
------------------------------------------------------------

src/esm.pyx:64:42: Cannot assign type 'ac_error_code (void *, ac_result *) except *' to 'ac_result_callback'
Traceback (most recent call last):
  File "/home/d/deleteme/esmre/setup.py", line 53, in <module>
    ext_modules=cythonize([module1]),
  File "/home/d/miniconda/envs/ai_workflow_env/lib/python3.9/site-packages/Cython/Build/Dependencies.py", line 1134, in cythonize
    cythonize_one(*args)
  File "/home/d/miniconda/envs/ai_workflow_env/lib/python3.9/site-packages/Cython/Build/Dependencies.py", line 1301, in cythonize_one
    raise CompileError(None, pyx_file)
Cython.Compiler.Errors.CompileError: src/esm.pyx
```

Trying to solve the errors, I have found the library `aho_corasick` may not support Cython 3 either. This goes beyond my knowledge.
For the short term, I suggest to still compile ESMRE using Cython<3.
