### PR TITLE
Make build work with Cython 3.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython<3"]
+requires = ["setuptools", "wheel", "Cython"]

--- a/src/esm.pyx
+++ b/src/esm.pyx
@@ -1,11 +1,11 @@
 cimport aho_corasick
 
-cdef aho_corasick.ac_error_code decref_result_object(void *item, void* data):
+cdef aho_corasick.ac_error_code decref_result_object(void *item, void* data) noexcept:
     aho_corasick.Py_DecRef(<object>item)
     return aho_corasick.AC_SUCCESS
 
 cdef aho_corasick.ac_error_code append_result(void* data,
-                                              aho_corasick.ac_result* result):
+                                              aho_corasick.ac_result* result) noexcept:
     result_list = <list>data
     result_tuple = ((result.start, result.end), <object>result.object)
     result_list.append(result_tuple)


### PR DESCRIPTION
Implicit `noexcept` is deprecated, as per the migration guide for Cython 3.x: https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html#exception-values-and-noexcept
